### PR TITLE
Renamed completeWithAsync to completeWithTask

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -115,7 +115,7 @@ public protocol AsyncLambdaHandler: EventLoopLambdaHandler {
 extension AsyncLambdaHandler {
     public func handle(context: Lambda.Context, event: In) -> EventLoopFuture<Out> {
         let promise = context.eventLoop.makePromise(of: Out.self)
-        promise.completeWithAsync {
+        promise.completeWithTask {
             try await self.handle(event: event, context: context)
         }
         return promise.futureResult
@@ -127,7 +127,7 @@ extension AsyncLambdaHandler {
     public static func main() {
         Lambda.run { context -> EventLoopFuture<ByteBufferLambdaHandler> in
             let promise = context.eventLoop.makePromise(of: ByteBufferLambdaHandler.self)
-            promise.completeWithAsync {
+            promise.completeWithTask {
                 try await Self(context: context)
             }
             return promise.futureResult


### PR DESCRIPTION
https://github.com/apple/swift-nio/commit/e66b64e4e3e3409729befb31d894b89062e003dc

In swift-nio completeWithAsync was renamed to completeWithTask

### Motivation:

completeWithAsync causes build errors on macOS 12 and Xcode 13

### Modifications:

Renamed completeWithAsync to completeWithTask

### Result:

No more build errors
